### PR TITLE
refactor: show full datetime for createdAt and updatedAt attributes in the info tab

### DIFF
--- a/src/components/info-tab/InfoTab.tsx
+++ b/src/components/info-tab/InfoTab.tsx
@@ -1,6 +1,6 @@
 import { h } from "preact";
 import style from "./style.module.css";
-import { getHHMMSS } from "../../utils/dates";
+import { formatDateTime } from "../../utils/dates";
 import { area, length } from "../../utils/geo";
 import { useMemo } from "preact/hooks";
 import { GeoJSONStoreFeatures } from "terra-draw/dist/store/store";
@@ -64,13 +64,13 @@ const InfoTab = ({
         <span class={style.row}>
           <span class={style.type}>Created</span>
           {selected && selected.properties.createdAt
-            ? getHHMMSS(selected.properties.createdAt as number)
+            ? formatDateTime(selected.properties.createdAt as number)
             : "N/A"}
         </span>
         <span class={style.row}>
           <span class={style.type}>Updated</span>
           {selected && selected.properties.updatedAt
-            ? getHHMMSS(selected.properties.updatedAt as number)
+            ? formatDateTime(selected.properties.updatedAt as number)
             : "N/A"}
         </span>
         <span class={style.row}>

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -1,6 +1,13 @@
 export const getHHMMSS = (timestamp: number) =>
   new Date(timestamp).toTimeString().split(" ")[0];
 
+
+export const formatDateTime = (timestamp: number) => {
+  const d = new Date(timestamp);
+  return `${d.toDateString()} ${d.toTimeString().split(" ")[0]}`;
+};
+
+
 export const fileDate = () =>
   new Date()
     .toISOString()


### PR DESCRIPTION
Hi James. First of all, this is such a cool project(terra-draw). Really having fun building with it and experimenting with it. Thanks a ton for all the work you are doing.

Now to my PR.

## Problem
While drawing features on the website, the createdAt and updatedAt fields only showed time value with no date, so it was difficult to distinguish features created on different days

## Fix
Updated the datetime formatter to display full date and time 
in the format `YYYY/MM/DD HH:MM:SS` i.e



## Before
createdAt: `01:47:32`
updatedAt: `02:38:02`

<img width="1465" height="1086" alt="image" src="https://github.com/user-attachments/assets/450e3ead-6d47-4a02-85f7-6a91bca6b827" />


## After
createdAt: `Sat Feb 21 2026 22:22:04`
updatedAt: `Sun Feb 22 2026 20:05:20`

<img width="1465" height="1086" alt="image" src="https://github.com/user-attachments/assets/6aee8aaf-e8a3-4b89-967a-e9b574f4a726" />

