### PR TITLE
fix: reset feature count to 0 after clearing drawn features on the map

### DIFF
--- a/src/components/clear-button/ClearButton.tsx
+++ b/src/components/clear-button/ClearButton.tsx
@@ -1,9 +1,17 @@
 import { h } from "preact";
 import style from "./style.module.css";
 import clear from "../../assets/imgs/clear.png";
-import { TerraDraw } from "terra-draw";
+import { GeoJSONStoreFeatures, TerraDraw } from "terra-draw";
 
-const ClearButton = ({ draw, clearLocalStorage }: { draw: TerraDraw, clearLocalStorage: () => void }) => {
+const ClearButton = ({
+  draw,
+  clearLocalStorage,
+  setFeatures,
+}: {
+  draw: TerraDraw;
+  clearLocalStorage: () => void;
+  setFeatures: (features: GeoJSONStoreFeatures[]) => void;
+}) => {
   const classes = style.button;
 
   return (
@@ -13,7 +21,8 @@ const ClearButton = ({ draw, clearLocalStorage }: { draw: TerraDraw, clearLocalS
       title={"Clear"}
       onClick={() => {
         draw.clear();
-        clearLocalStorage()
+        clearLocalStorage();
+        setFeatures([]);
       }}
     >
       <img class={style.clear} src={clear} />

--- a/src/routes/home/index.tsx
+++ b/src/routes/home/index.tsx
@@ -107,7 +107,7 @@ const Home = () => {
               }}
             />
           ) : null}
-          {draw ? <ClearButton draw={draw} clearLocalStorage={clearLocalStorage} /> : null}
+          {draw ? <ClearButton draw={draw} clearLocalStorage={clearLocalStorage} setFeatures={setFeatures} /> : null}
         </div>
         {draw ? <MapButtons mode={mode} changeMode={changeMode} /> : null}
       </div>


### PR DESCRIPTION
Hello James, hope you are well.

Another day, another PR

## Problem
After clicking clear button on the map to delete features on the map, the feature count is not updated

## Fix
Update feature count to 0 after clearing


## Before
<img width="265" height="186" alt="Screenshot 2026-02-23 at 17 47 39" src="https://github.com/user-attachments/assets/3a63458a-5f24-4330-9760-811754ae9541" />


## After
<img width="265" height="186" alt="image" src="https://github.com/user-attachments/assets/ebae447a-0b99-4e0c-909b-31f228ea39a0" />
