### PR TITLE
feat: add polyline mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,8 +20,8 @@
         "preact-iso": "^2.6.3",
         "preact-render-to-string": "^6.5.10",
         "preact-router": "^3.2.1",
-        "terra-draw": "1.28.1",
-        "terra-draw-maplibre-gl-adapter": "1.3.0"
+        "terra-draw": "1.31.0",
+        "terra-draw-maplibre-gl-adapter": "1.4.0"
       },
       "devDependencies": {
         "@preact/preset-vite": "^2.10.5",
@@ -83,6 +83,7 @@
       "integrity": "sha512-BBt3opiCOxUr9euZ5/ro/Xv8/V7yJ5bjYMqG/C1YAo8MIKAnumZalCN+msbci3Pigy4lIQfPUpfMM27HMGaYEA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.24.7",
@@ -1924,7 +1925,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.0",
         "tslib": "^2.4.0"
@@ -1936,8 +1936,7 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.9.1",
@@ -1946,7 +1945,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1957,8 +1955,7 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.0",
@@ -1967,7 +1964,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1978,8 +1974,7 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.4.0",
@@ -3367,6 +3362,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.47.0.tgz",
       "integrity": "sha512-AHZtlXAMGkDmyLuLZsRpH3p4G/1iARIwc/T0vIem2YB+xW6pZaXYXzCBnZSF/5fdM97R9QqZWZ+h3iW10XgevQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.47.0",
         "@typescript-eslint/type-utils": "5.47.0",
@@ -3419,6 +3415,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.47.0.tgz",
       "integrity": "sha512-udPU4ckK+R1JWCGdQC4Qa27NtBg7w020ffHqGyAK8pAgOVuNw7YaKXGChk+udh+iiGIJf6/E/0xhVXyPAbsczw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.47.0",
         "@typescript-eslint/types": "5.47.0",
@@ -3580,6 +3577,7 @@
       "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4066,6 +4064,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001646",
         "electron-to-chromium": "^1.5.4",
@@ -4726,6 +4725,7 @@
       "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.11.0.tgz",
       "integrity": "sha512-Dw8/Gs4vRjxY6/6i9wU0V+utmQO9kvh9XLnz3LIudviOnVYDEe2ec+0k+NQoMamn1VrjKgCUOWj5jG/5M5M0Qw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "array.prototype.flat": "^1.2.3",
         "cheerio": "^1.0.0-rc.3",
@@ -5006,6 +5006,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.30.0.tgz",
       "integrity": "sha512-MGADB39QqYuzEGov+F/qb18r4i7DohCDOfatHaxI2iGlPuC65bwG2gxgO+7DkyL38dRFaRH7RaRAgU6JKL9rMQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.4.0",
         "@humanwhocodes/config-array": "^0.11.8",
@@ -6598,6 +6599,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-27.5.1.tgz",
       "integrity": "sha512-Yn0mADZB89zTtjkPJEXwrac3LHudkQMR+Paqa8uxJHCBr9agxztUifWCyiYrjhMPBoUVBjyny0I7XH6ozDr7QQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@jest/core": "^27.5.1",
         "import-local": "^3.0.2",
@@ -9759,6 +9761,7 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.0.tgz",
       "integrity": "sha512-wSAGyk2bYR1c7t3SZ3jHcM6xy0lcBcDel6lODcs9ME6Th++Dx2KU+6D3HD8wMMKGA8Wpw7OMd3/4RGzYRpzwRg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -9779,6 +9782,7 @@
       "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.5.10.tgz",
       "integrity": "sha512-BJdypTQaBA5UbTF9NKZS3zP93Sw33tZOxNXIfuHofqOZFoMdsquNkVebs/HkEw0in/Qbi6Ep/Anngnj+VsHeBQ==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "preact": ">=10"
       }
@@ -10720,15 +10724,16 @@
       }
     },
     "node_modules/terra-draw": {
-      "version": "1.28.1",
-      "resolved": "https://registry.npmjs.org/terra-draw/-/terra-draw-1.28.1.tgz",
-      "integrity": "sha512-am4wl99vjmohq0lR0QLrAB5YqbDodusAJO8Cn3pXZa+9DXFdgOWHVfyCfgMiNST4cKFO3IFuSZhxtmhXbFvUtA==",
-      "license": "MIT"
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/terra-draw/-/terra-draw-1.31.0.tgz",
+      "integrity": "sha512-4tNhOHL+Oj749Ih2dRvjq8L/JvutBo+tgj8alLs002YiGIgXc57XoiC+zfzRQn/r1+N2BqU18FgC9DQXJiZADw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/terra-draw-maplibre-gl-adapter": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/terra-draw-maplibre-gl-adapter/-/terra-draw-maplibre-gl-adapter-1.3.0.tgz",
-      "integrity": "sha512-Q0Kds+IxLIcMPv3xYAJ3TDXp1Ml1uGk2xFN8Xx5tKpVdU9AhlTkpGxJ7i+Is1v6PC4t+O7MfyGP4Tl+R+qdYeQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/terra-draw-maplibre-gl-adapter/-/terra-draw-maplibre-gl-adapter-1.4.0.tgz",
+      "integrity": "sha512-q0k+HRnMpI4k6GLx4Q9seCo9Q1ujmQAjELfo1l4JrS/VNcSaV5mKcSw5b3uaTws8Ni5BZamm2jZwXjRkwqxoag==",
       "license": "MIT",
       "peerDependencies": {
         "maplibre-gl": ">=4",
@@ -10802,6 +10807,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10930,6 +10936,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11131,6 +11138,7 @@
       "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "preact-iso": "^2.6.3",
     "preact-render-to-string": "^6.5.10",
     "preact-router": "^3.2.1",
-    "terra-draw": "1.28.1",
-    "terra-draw-maplibre-gl-adapter": "1.3.0"
+    "terra-draw": "1.31.0",
+    "terra-draw-maplibre-gl-adapter": "1.4.0"
   },
   "devDependencies": {
     "@preact/preset-vite": "^2.10.5",

--- a/src/components/map-buttons/MapButtons.tsx
+++ b/src/components/map-buttons/MapButtons.tsx
@@ -70,6 +70,7 @@ const MapButtons = ({
           hiddenOnTouch={true}
         />
         <MapButton mode={"polygon"} currentMode={mode} changeMode={changeMode} />
+        <MapButton mode={"polyline"} currentMode={mode} changeMode={changeMode} />
         <MapButton
           mode={"freehand"}
           currentMode={mode}

--- a/src/routes/home/setup-draw.ts
+++ b/src/routes/home/setup-draw.ts
@@ -3,6 +3,7 @@ import {
   TerraDrawSelectMode,
   TerraDrawPointMode,
   TerraDrawLineStringMode,
+  TerraDrawPolyLineMode,
   TerraDrawPolygonMode,
   TerraDrawCircleMode,
   TerraDrawFreehandMode,
@@ -55,6 +56,16 @@ export function setupDraw(map: maplibregl.Map) {
               },
             },
           },
+          polyline: {
+            feature: {
+              draggable: true,
+              coordinates: {
+                midpoints: true,
+                draggable: true,
+                deletable: true,
+              },
+            },
+          },
           circle: {
             feature: {
               draggable: true,
@@ -82,6 +93,16 @@ export function setupDraw(map: maplibregl.Map) {
       }),
       new TerraDrawPointMode(),
       new TerraDrawLineStringMode({
+        validation: (feature, { updateType }) => {
+          if (updateType === "finish" || updateType === "commit") {
+            return ValidateNotSelfIntersecting(feature);
+          }
+          return {
+            valid: true
+          }
+        }
+      }),
+      new TerraDrawPolyLineMode({
         validation: (feature, { updateType }) => {
           if (updateType === "finish" || updateType === "commit") {
             return ValidateNotSelfIntersecting(feature);


### PR DESCRIPTION
### Why?
Adds the new Polyline mode to the playground, exposing Terra Draw's TerraDrawPolyLineMode. Users can now draw polylines directly from the map toolbar alongside the existing modes (point, linestring, polygon, freehand, etc.).

### Changes
- Bump Terra Draw dependencies to pick up the new mode:
  - terra-draw 1.28.1 → 1.31.0
  - terra-draw-maplibre-gl-adapter 1.3.0 → 1.4.0
- Register TerraDrawPolyLineMode in setup-draw.ts with self-intersection validation on finish/commit (consistent with the other line/polygon modes).
- Configure select-mode styling for polyline features: draggable features, draggable/deletable coordinates, and midpoints.
- Add a polyline toolbar button in MapButtons.tsx, placed after the polygon button.

### Screenshot
<img width="1716" height="992" alt="Screenshot 2026-06-05 at 14 19 59" src="https://github.com/user-attachments/assets/9ee0b969-a0be-4a71-8b42-a90204de23e1" />

### Notes
Recently had to use TerrraDraw when migrating off google map api. The recently added polyline mode (Thank you for adding this 🔥 ) was a perfect fit for my use case. I somehow missed the Mode documentation and thought this mode was not available as I tried out the website.